### PR TITLE
feat(plugin): add 25 and 75 transparent background classes

### DIFF
--- a/scss/mixins/transparent-backgrounds.scss
+++ b/scss/mixins/transparent-backgrounds.scss
@@ -4,7 +4,7 @@
 // Creates a selector based on the $parent provided and the $colour and $value given.
 // ----------
 
-// sass-lint:disable-line no-color-literals
+// sass-lint:disable no-color-literals
 
 @mixin transparent-background-variant($parent, $colour, $value) {
   #{$parent} {

--- a/scss/utilities/transparent-backgrounds.scss
+++ b/scss/utilities/transparent-backgrounds.scss
@@ -9,4 +9,8 @@
 
     @include transparent-background-variant($class, $hex, $value);
   }
+
+  // Add classes for 25% and 75%.
+  @include transparent-background-variant('.bg-#{$name}-25', $hex, .25);
+  @include transparent-background-variant('.bg-#{$name}-75', $hex, .75);
 }


### PR DESCRIPTION
## Description

25% and 75% are semi-common uses for transparencies. Adding them as base classes.
